### PR TITLE
fix data.content.channel definition

### DIFF
--- a/standard/recommendations/monitoring-event-message-core/REC_data_channel.adoc
+++ b/standard/recommendations/monitoring-event-message-core/REC_data_channel.adoc
@@ -1,7 +1,0 @@
-[[rec_monitoring-event-message-core_data_channel]]
-[width="90%",cols="2,6a"]
-|===
-^|*Recommendation {counter:rec-id}* |*/rec/monitoring-event-message-core/data_channel*
-^|A |The `+channel+` property SHOULD be used if the event is based on data being published to a given topic.
-|===
-

--- a/standard/recommendations/monitoring-event-message-core/REC_data_content_channel.adoc
+++ b/standard/recommendations/monitoring-event-message-core/REC_data_content_channel.adoc
@@ -1,0 +1,7 @@
+[[rec_monitoring-event-message-core_data_content_channel]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/monitoring-event-message-core/data_content_channel*
+^|A |A WMEM SHOULD provide a `+data.content.channel+` property if the event is based on data being published to a given topic.
+|===
+

--- a/standard/sections/clause_8_event_message_core.adoc
+++ b/standard/sections/clause_8_event_message_core.adoc
@@ -77,10 +77,6 @@ The table below provides an overview of the set of properties that are included 
 |Optional
 |The identifier that the event is referencing (see <<_data_ref>>)
 
-|``data.channel``
-|Optional
-|The WIS2 channel related to the event (see <<_data_channel>>)
-
 |``data.time``
 |Optional
 |The date/time associated with the event (see <<_data_time>>)
@@ -285,18 +281,6 @@ Example:
 "ref": "6da24af0-b19f-4106-b583-73cc25a4435d"
 ----
 
-==== Data channel
-
-The ``data.channel`` property defines a WIS2 topic that the event may be referring to (for example for a data outage notice).
-
-Example:
-[source,json]
-----
-"channel": "origin/a/wis2/ar-smn/data/core/weather/surface-based-observations/synop"
-----
-
-include::../recommendations/monitoring-event-message-core/REC_data_channel.adoc[]
-
 ==== Data time
 
 The ``data.time`` property defines time interval that the WMEM may be referring to (for example for a data outage notice).
@@ -366,6 +350,18 @@ Example:
 
 include::../requirements/monitoring-event-message-core/REQ_data_content.adoc[]
 include::../recommendations/monitoring-event-message-core/PER_data_content.adoc[]
+
+==== Data content channel
+
+The ``data.content.channel`` property defines a WIS2 topic that the event may be referring to (for example for a data outage notice).
+
+Example:
+[source,json]
+----
+"channel": "origin/a/wis2/ar-smn/data/core/weather/surface-based-observations/synop"
+----
+
+include::../recommendations/monitoring-event-message-core/REC_data_content_channel.adoc[]
 
 ===== Data content title
 


### PR DESCRIPTION
This PR fixes `data.content.channel` placement to be defined under the `data.content` section in the specification.

A [PDF](https://github.com/user-attachments/files/26602884/wis2-monitoring-events.pdf) is also provided for reviewing in context.

Thanks to @mgiannoni for catching.
