### PR TITLE
WMEM: add more types and remove data.subtype (#27)

### DIFF
--- a/examples/wmem-gb-wnm-report.json
+++ b/examples/wmem-gb-wnm-report.json
@@ -1,7 +1,7 @@
 {
     "id": "08361ecb-e7ff-4965-9abe-465b63433ca5",
     "specversion": "1.0",
-    "type": "int.wmo.wis.wme.event",
+    "type": "int.wmo.wis.wme.event.wnm.validation",
     "source": "io-wis2dev-global-broker",
     "subject": "io-wis2dev-12-test",
     "time": "2024-12-11T12:54:40.605Z",
@@ -11,7 +11,6 @@
         "conformsTo": [
             "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
         ],
-        "subtype": "wnm-report",
         "severity": "ERROR",
         "content": {
             "channel": "cache/a/wis2/de-dwd-gts-to-wis2/data/recommended/U/A/N/T/99/KDDL",

--- a/examples/wmem-gc-404-report.json
+++ b/examples/wmem-gc-404-report.json
@@ -1,7 +1,7 @@
 {
     "id": "6e1c7f9f-dd6c-48d9-bbc4-aef0625f1fb8",
     "specversion": "1.0",
-    "type": "int.wmo.wis.wme.event",
+    "type": "int.wmo.wis.wme.event.item.download",
     "source": "jp-jma-global-cache",
     "subject": "ca-eccc-msc",
     "time": "2024-10-17T05:13:22Z",
@@ -11,7 +11,6 @@
         "conformsTo": [
             "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
         ],
-        "subtype": "gc-error",
         "severity": "ERROR",
         "content": {
             "title": "Cannot download data granule: https://example.org/404"

--- a/examples/wmem-gc-alert-report.json
+++ b/examples/wmem-gc-alert-report.json
@@ -1,8 +1,8 @@
 {
     "id": "6e1c7f9f-dd6c-48d9-bbc4-aef0625f1fb8",
     "specversion": "1.0",
-    "type": "int.wmo.wis.wme.event",
-    "source": "ca-eccc-msc-global-discovery-catalogue",
+    "type": "int.wmo.wis.wme.event.metadata-archive",
+    "source": "de-dwd-global-cache",
     "subject": "ca-eccc-msc-global-discovery-catalogue",
     "time": "2024-10-17T05:13:22Z",
     "datacontenttype": "application/json",
@@ -11,7 +11,6 @@
         "conformsTo": [
             "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
         ],
-        "subtype": "gc-alert",
         "severity": "CRITICAL",
         "content": {
             "title": "Metadata archive is older than 24 hours",

--- a/examples/wmem-gdc-wcmp2-ets.json
+++ b/examples/wmem-gdc-wcmp2-ets.json
@@ -1,7 +1,7 @@
 {
     "id": "6e1c7f9f-dd6c-48d9-bbc4-aef0625f1fb8",
     "specversion": "1.0",
-    "type": "int.wmo.wis.wme.event",
+    "type": "int.wmo.wis.wme.event.wcmp2.ets",
     "source": "ca-eccc-msc-global-discovery-catalogue",
     "subject": "de-dwd",
     "time": "2024-10-17T05:13:22Z",
@@ -11,7 +11,6 @@
         "conformsTo": [
             "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
         ],
-        "subtype": "wcmp2-ets",
         "severity": "INFO",
         "content": {
             "id": "f84f34d6-cfb0-4cff-98ec-32f88d0fd7b8",

--- a/examples/wmem-gdc-wcmp2-kpi.json
+++ b/examples/wmem-gdc-wcmp2-kpi.json
@@ -1,7 +1,7 @@
 {
     "id": "6e1c7f9f-dd6c-48d9-bbc4-aef0625f1fb8",
     "specversion": "1.0",
-    "type": "int.wmo.wis.wme.event",
+    "type": "int.wmo.wis.wme.event.wcmp2.kpi",
     "source": "ca-eccc-msc-global-discovery-catalogue",
     "subject": "de-dwd",
     "time": "2025-02-01T18:19:37Z",
@@ -11,7 +11,6 @@
         "conformsTo": [
             "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
         ],
-        "subtype": "wcmp2-kpi",
         "severity": "INFO",
         "content": {
             "id": "38631309-36b7-4c71-a7cd-aaca48f81a49",

--- a/examples/wmem-wis2node-outage.json
+++ b/examples/wmem-wis2node-outage.json
@@ -2,8 +2,8 @@
     "id": "6e1c7f9f-dd6c-48d9-bbc4-aef0625f1fb8",
     "specversion": "1.0",
     "type": "int.wmo.wis.wme.event",
-    "source": "ca-eccc-msc",
-    "subject": "ca-eccc-msc",
+    "source": "br-inmet",
+    "subject": "br-inmet",
     "time": "2025-12-29T05:13:22Z",
     "datacontenttype": "application/json",
     "dataschema": "https://schemas.wmo.int/wme/1.0.0/schemas/wis2-event-message-bundled.json",
@@ -21,7 +21,7 @@
         "content": {
             "title": "Data outage notice",
             "description": "Surface synoptic observations will be missing on 05 January 2026 at 14h UTC for a 3 hour period",
-            "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/surface-based-observations/synop"
+            "channel": "origin/a/wis2/br-inmet/data/core/weather/surface-based-observations/synop"
         }
     }
 }

--- a/schemas/monitoringEventMessageJSON.yaml
+++ b/schemas/monitoringEventMessageJSON.yaml
@@ -8,17 +8,13 @@ allOf:
   - properties:
       type:
         type: string
-        enum:
-          - int.wmo.wis.wme.event
+        description: The type of event related to the event message.
       data:    
         properties:
           conformsTo:
             type: array
             contains:
                 const: http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core
-          subtype:
-            type: string
-            description: A string further describing the event type
           severity:
             type: string
             description: Severity level

--- a/schemas/wis2-event-message-bundled.json
+++ b/schemas/wis2-event-message-bundled.json
@@ -11,9 +11,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "int.wmo.wis.wme.event"
-          ]
+          "description": "The type of event related to the event message."
         },
         "data": {
           "properties": {
@@ -22,10 +20,6 @@
               "contains": {
                 "const": "http://wis.wmo.int/spec/wme/1/conf/monitoring-event-message-core"
               }
-            },
-            "subtype": {
-              "type": "string",
-              "description": "A string further describing the event type"
             },
             "severity": {
               "type": "string",

--- a/standard/abstract_tests/monitoring-event-message-core/ATS_test_type.adoc
+++ b/standard/abstract_tests/monitoring-event-message-core/ATS_test_type.adoc
@@ -14,7 +14,7 @@ Check for the existence of a `+type+` property in the WMEM.
 
 [.component,class=step]
 --
-Check that the `+type+` property begins with `int.wmo.wis.wme.event`.
+Check that the value of properties.type is part of the https://github.com/wmo-im/wis2-monitoring-events-codelists/blob/main/codelists/event-type.csv[WMEM event type codelist].
 --
 
 =====

--- a/standard/requirements/monitoring-event-message-core/REQ_type.adoc
+++ b/standard/requirements/monitoring-event-message-core/REQ_type.adoc
@@ -3,5 +3,6 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/monitoring-event-message-core/type*
 ^|A |The `+type+` property SHALL be encoded using a reverse DNS notation.
-^|B |The `+type+` property SHALL be equal to `int.wmo.wis.wme.event`
+^|B |The `+type+` property SHALL be a valid code from the WMEM event type code list.
+
 |===

--- a/standard/sections/annex_c_examples.adoc
+++ b/standard/sections/annex_c_examples.adoc
@@ -47,7 +47,7 @@ include::../../examples/wmem-gb-wnm-report.json[]
 
 === WIS2 Monitoring Event Message: Notice Report
 
-.Example: Notice report event notification from the EUMETSAT WIS2 Node, concerning a forthcoming data outage
+.Example: Notice report event notification from the Instituto Nacional de Meteorología (Brazil) WIS2 Node, concerning a forthcoming data outage
 [source,json]
 ----
 include::../../examples/wmem-wis2node-outage.json[]

--- a/standard/sections/clause_8_event_message_core.adoc
+++ b/standard/sections/clause_8_event_message_core.adoc
@@ -65,10 +65,6 @@ The table below provides an overview of the set of properties that are included 
 |**Required**
 |The version of WME associated to which the event message conforms (see <<_data_conformance>>)
 
-|``data.subtype``
-|Optional
-|A string further describing the event type (see <<_data_subtype>>)
-
 |``data.severity``
 |**Required**
 |The severity level of the event (see <<_data_severity>>)
@@ -135,7 +131,7 @@ The type of event related to the event message, using a reverse DNS notation.
 Example:
 [source,json]
 ----
-"type": "int.wmo.wis.wme.event"
+"type": "int.wmo.wis.wme.event.wcmp2.ets"
 ----
 
 include::../requirements/monitoring-event-message-core/REQ_type.adoc[]
@@ -249,15 +245,6 @@ The ``conformsTo`` property identifies the version of the WME standard to which 
 ----
 
 include::../requirements/monitoring-event-message-core/REQ_data_conformance.adoc[]
-
-==== Data subtype
-
-The ``subtype`` property further describes a given event type.  This value can be useful for deeper observability and filtering of monitoring messages for dedicated workflows.
-
-[source,json]
-----
-"subtype": "wcmp2-ets"
-----
 
 ==== Data severity
 


### PR DESCRIPTION
Fixes #27.  Notes:

- a PDF is [attached](https://github.com/user-attachments/files/27428969/wis2-monitoring-events.pdf) to review in context
- I've updated some of the `type` values to be resource centric (vs. service centric).  Once this is further addressed in https://github.com/wmo-im/wis2-guide/issues/233, we can update in a subsequent PR
- the `type` values are managed in https://github.com/wmo-im/wis2-monitoring-events-codelists with similar setup/workflow as WCMP2 codelists